### PR TITLE
Replace retired DeepSeek default model and target SDK 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,9 +49,7 @@ android {
     defaultConfig {
         applicationId = "com.jarves.mh"
         minSdk = 28
-        // The direct APK retains the proven target-28 PRoot execution path. The
-        // Play build targets current Android while its runtime path is validated.
-        targetSdk = if (playBuild) 36 else 28
+        targetSdk = 36
         // Keep literal defaults so F-Droid's static manifest parser can detect
         // the tagged release. Gradle properties may still override Play builds.
         versionCode = 3

--- a/app/src/main/java/com/jarves/mh/ui/PocketDevApp.kt
+++ b/app/src/main/java/com/jarves/mh/ui/PocketDevApp.kt
@@ -1486,7 +1486,7 @@ private fun ProviderSetupScreen(
     var step by rememberSaveable { mutableIntStateOf(initialStep) }
     var selected by rememberSaveable { mutableStateOf(initial.kind) }
     var baseUrl by rememberSaveable { mutableStateOf(initial.baseUrl.ifBlank { "https://api.deepseek.com/anthropic" }) }
-    var model by rememberSaveable { mutableStateOf(initial.model.ifBlank { "deepseek-chat" }) }
+    var model by rememberSaveable { mutableStateOf(initial.model.ifBlank { "deepseek-v4-flash" }) }
     var apiKey by rememberSaveable { mutableStateOf("") }
 
     val handleBack: (() -> Unit)? = when {
@@ -1541,7 +1541,7 @@ private fun ProviderSetupScreen(
                             } else {
                                 it.defaultBaseUrl
                             }
-                            model = if (it == ProviderKind.CUSTOM) "deepseek-chat" else it.defaultModel
+                            model = if (it == ProviderKind.CUSTOM) "deepseek-v4-flash" else it.defaultModel
                             apiKey = ""
                         }
                     },

--- a/app/src/main/java/com/jarves/mh/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/jarves/mh/ui/SettingsScreen.kt
@@ -112,7 +112,7 @@ private fun LegacySettingsScreen(
         mutableStateOf(state.provider.baseUrl.ifBlank { "https://api.deepseek.com/anthropic" })
     }
     var model by rememberSaveable(state.provider.model) {
-        mutableStateOf(state.provider.model.ifBlank { "deepseek-chat" })
+        mutableStateOf(state.provider.model.ifBlank { "deepseek-v4-flash" })
     }
     var apiKey by rememberSaveable { mutableStateOf(getSavedApiKey(state.provider.kind)) }
     var keyVisible by rememberSaveable { mutableStateOf(false) }
@@ -344,7 +344,7 @@ private fun LegacySettingsScreen(
                             )
                             Spacer(Modifier.height(2.dp))
                             Text(
-                                state.provider.model.ifBlank { "deepseek-chat" },
+                                state.provider.model.ifBlank { "deepseek-v4-flash" },
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 15.sp,
                             )
@@ -421,7 +421,7 @@ private fun LegacySettingsScreen(
                                         } else {
                                             kind.defaultBaseUrl
                                         }
-                                        model = if (kind == ProviderKind.CUSTOM) "deepseek-chat" else kind.defaultModel
+                                        model = if (kind == ProviderKind.CUSTOM) "deepseek-v4-flash" else kind.defaultModel
                                         val saved = getSavedApiKey(kind)
                                         apiKey = saved
                                         validationStatus = null

--- a/app/src/main/java/com/jarves/mh/ui/SettingsScreenModern.kt
+++ b/app/src/main/java/com/jarves/mh/ui/SettingsScreenModern.kt
@@ -286,7 +286,7 @@ fun SettingsScreen(
                         onProvider = { kind ->
                             selectedKind = kind
                             baseUrl = if (kind == ProviderKind.CUSTOM || kind == ProviderKind.ANTHROPIC) "https://api.deepseek.com/anthropic" else kind.defaultBaseUrl
-                            model = if (kind == ProviderKind.CUSTOM) "deepseek-chat" else kind.defaultModel
+                            model = if (kind == ProviderKind.CUSTOM) "deepseek-v4-flash" else kind.defaultModel
                             apiKey = getSavedApiKey(kind)
                             models = emptyList()
                             status = null


### PR DESCRIPTION
## What is this?

Two small defaults were out of date, so fresh installs started broken. This PR fixes both.

## What changes for you

- The app no longer suggests deepseek-chat (retired, rejected by the API). It now suggests deepseek-v4-flash, which works out of the box.
- The app now targets Android SDK 36 in every build. Before, the Play build was on 36 but the direct APK stayed on 28, so the same app behaved differently depending on where you got it.

## Why

- New users hit a dead default model: setup finished, but every call failed because the model name no longer exists. Pointing at the current Flash model removes that first-run failure.
- One target SDK means one behavior to test, and it keeps the app within current Play requirements instead of shipping an old target just for the APK.

## Heads-up

- Moving the direct APK from target 28 to 36 changes how it runs on newer Android (permissions, background work). Worth a quick smoke test on a real device, especially the terminal and runtime path.

## Files

- Provider setup and settings screens (default model string only)
- app/build.gradle.kts (targetSdk = 36)

## Testing

- Tested on Xiaomi Pad 8.
- No logic changed, config defaults only.