### PR TITLE
fix(runtime): reject unauthenticated requests to the local format gateway

### DIFF
--- a/app/src/main/java/com/jarves/mh/runtime/LocalFormatGateway.kt
+++ b/app/src/main/java/com/jarves/mh/runtime/LocalFormatGateway.kt
@@ -9,6 +9,7 @@ import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.URL
+import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONArray
@@ -30,6 +31,7 @@ internal class LocalFormatGateway(
     private fun acceptLoop() {
         while (running.get()) {
             runCatching { server.accept() }.getOrNull()?.let { socket ->
+                runCatching { socket.soTimeout = SOCKET_TIMEOUT_MS }
                 Thread({ socket.use(::handle) }, "mh-format-request").apply { isDaemon = true; start() }
             }
         }
@@ -45,7 +47,16 @@ internal class LocalFormatGateway(
             val split = line.indexOf(':')
             if (split > 0) headers[line.substring(0, split).lowercase()] = line.substring(split + 1).trim()
         }
+        val output = BufferedOutputStream(socket.getOutputStream())
+        if (!isAuthorized(headers)) {
+            writeJson(output, 401, errorJson("authentication_error", "Missing or invalid credentials"))
+            return
+        }
         val length = headers["content-length"]?.toIntOrNull() ?: 0
+        if (length !in 0..MAX_REQUEST_BYTES) {
+            writeJson(output, 413, errorJson("invalid_request_error", "Request body is too large"))
+            return
+        }
         val bodyBytes = ByteArray(length)
         var offset = 0
         while (offset < length) {
@@ -54,7 +65,6 @@ internal class LocalFormatGateway(
             offset += count
         }
         val path = requestLine.split(' ').getOrNull(1).orEmpty().substringBefore('?')
-        val output = BufferedOutputStream(socket.getOutputStream())
         if (path.endsWith("/count_tokens")) {
             val approximate = bodyBytes.decodeToString().length / 4 + 1
             writeJson(output, 200, JSONObject().put("input_tokens", approximate).toString())
@@ -211,6 +221,21 @@ internal class LocalFormatGateway(
         output.flush()
     }
 
+    /**
+     * Only forward requests that present the provider key Claude Code was configured with.
+     *
+     * Binding to 127.0.0.1 keeps this server off the network, but it does not make it
+     * private: on Android any app with the INTERNET permission can connect to a loopback
+     * port. Without this check, another installed app could have its requests forwarded
+     * upstream on the user's key.
+     */
+    private fun isAuthorized(headers: Map<String, String>): Boolean {
+        val presented = headers["x-api-key"]
+            ?: headers["authorization"]?.removePrefix("Bearer ")?.trim()
+            ?: return false
+        return MessageDigest.isEqual(presented.toByteArray(), apiKey.toByteArray())
+    }
+
     private fun readLine(input: BufferedInputStream): String? {
         val bytes = ArrayList<Byte>()
         while (true) {
@@ -250,5 +275,10 @@ internal class LocalFormatGateway(
     override fun close() {
         running.set(false)
         runCatching { server.close() }
+    }
+
+    private companion object {
+        const val MAX_REQUEST_BYTES = 8 * 1024 * 1024
+        const val SOCKET_TIMEOUT_MS = 30_000
     }
 }

--- a/app/src/test/java/com/jarves/mh/runtime/LocalFormatGatewayTest.kt
+++ b/app/src/test/java/com/jarves/mh/runtime/LocalFormatGatewayTest.kt
@@ -1,0 +1,49 @@
+package com.jarves.mh.runtime
+
+import com.jarves.mh.model.ProviderKind
+import com.jarves.mh.model.ProviderProfile
+import java.net.Socket
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalFormatGatewayTest {
+
+    /** Sends a bodyless request and returns the HTTP status line. */
+    private fun status(headers: List<String>): String {
+        val gateway = LocalFormatGateway(
+            ProviderProfile(ProviderKind.CUSTOM, "https://provider.invalid/v1", "test-model", true),
+            apiKey = KEY,
+        ).start()
+        try {
+            val port = gateway.url.substringAfterLast(':').toInt()
+            return Socket("127.0.0.1", port).use { socket ->
+                socket.soTimeout = 5_000
+                val request = "POST /v1/messages HTTP/1.1\r\nHost: 127.0.0.1\r\n" +
+                    headers.joinToString("") { "$it\r\n" } + "\r\n"
+                socket.getOutputStream().apply { write(request.toByteArray()); flush() }
+                socket.getInputStream().bufferedReader().readLine().orEmpty()
+            }
+        } finally {
+            gateway.close()
+        }
+    }
+
+    @Test
+    fun rejectsRequestWithoutCredentials() {
+        assertTrue(status(listOf("Content-Length: 0")).contains("401"))
+    }
+
+    @Test
+    fun rejectsRequestWithWrongCredentials() {
+        assertTrue(status(listOf("x-api-key: wrong-key", "Content-Length: 0")).contains("401"))
+    }
+
+    @Test
+    fun rejectsOversizedRequestBeforeAllocating() {
+        assertTrue(status(listOf("x-api-key: $KEY", "Content-Length: 2000000000")).contains("413"))
+    }
+
+    private companion object {
+        const val KEY = "test-provider-key"
+    }
+}


### PR DESCRIPTION
`LocalFormatGateway` binds an HTTP server to `127.0.0.1` and forwards `/messages` upstream with
the user's provider key attached, without checking who sent the request.

Loopback isn't private on Android: any installed app holding the ordinary `INTERNET` permission
can connect to a loopback port, and there's no UID check on the connection. Such an app can't
read the key — it's attached server-side — but it can spend it, and nothing surfaces in the UI.

Claude Code already sends its configured key as `x-api-key` and the gateway already holds that
key, so requests can be checked against it. Anything else gets a `401`.

Two adjacent limits in the same function:

- `Content-Length` sized a `ByteArray` directly; over 8 MB now returns `413` before allocating.
- Accepted sockets had no read timeout; now 30s.

**Not reachable on `main`.** The gateway is only constructed for `OPENAI_CHAT` /
`OPENAI_RESPONSES`, and no `ProviderKind` maps to either — so this is hardening ahead of that
path being wired, with no behaviour change for current providers. Close it if you'd rather
handle this when an OpenAI-compatible provider actually lands.

Tests cover missing credentials, wrong credentials, and an oversized `Content-Length`, driven
over a real loopback socket with no upstream call. I haven't run the suite locally, so it's
worth a build before merge.